### PR TITLE
Update README: docker-compose down from named file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can check on the sync progress of your local node in the admin panel.
 If your node fails to sync or you want to try syncing from scratch you can run:
 
 ```bash
-$ docker-compose down --volumes
+$ docker-compose -f docker-compose.dev.yml down --volumes
 ```
 ## What's next?
 Once your node is synced, you have access to the full firehose of BitClout


### PR DESCRIPTION
there is no docker-compose.yml in the repo, since the file is named differently it must be reflected in the docker-compose down --volumes command.