### PR TITLE
Run run.sh in any dir

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,10 @@ DOCKER_COMPOSE_FILENAME=docker-compose.dev.yml
 
 set -e
 
+RUN_ROOT="$(dirname "$0")"
+
+pushd $RUN_ROOT
+
 if ! [ -x "$(command -v docker-compose)" ]; then
     echo "Please install docker and docker-compose: https://docs.docker.com/get-docker/"
     exit 1
@@ -11,3 +15,5 @@ fi
 
 docker-compose -f ${DOCKER_COMPOSE_FILENAME} pull || ( echo -e "\n\n\nTry running ./run.sh with sudo" && exit 1 )
 docker-compose -f ${DOCKER_COMPOSE_FILENAME} up "$@"
+
+popd


### PR DESCRIPTION
It seems counter intuitive to limit the bash script to only run at the project root.

This should allow a user to call the script anywhere.

E.g. This would break with the current setup.
```bash
./bit/clout/run.sh
```