### PR TITLE
add new /api route to nginx

### DIFF
--- a/nginx.dev
+++ b/nginx.dev
@@ -10,6 +10,10 @@ http {
       proxy_pass http://frontend:8080;
     }
 
+    location /api/ {
+      proxy_pass http://core:17001;
+    }
+
     listen 80;
     # listen 443 ssl;
     # ssl_certificate /etc/letsencrypt/live/server2.your.domain/fullchain.pem;


### PR DESCRIPTION
@maebeam [announced new api routes ](https://bitclout.com/posts/08c7887353f5721ef6ded1e6bd544452929fd3e51fec9512cf681b54830bb6b2) and frontend image on `latest` is now using them but nginx config does not support the api route on the main domain yet.

This PR adds the `/api/` location to the main domain nginx config but also leaves old api.domain.com server section in place for now.