### PR TITLE
Update Caddyfile blockchain URLs

### DIFF
--- a/Caddyfile.dev
+++ b/Caddyfile.dev
@@ -18,8 +18,8 @@
         bitclout.me:* api.bitclout.me:*
         localhost:*
         explorer.bitclout.com:*
-        https://blockchain.info/ticker
-        api.blockchain.info/mempool/fees
+        https://api.blockchain.com/ticker
+        https://api.blockchain.com/mempool/fees
         https://ka-f.fontawesome.com/
         bitcoinfees.earn.com
         api.blockcypher.com 


### PR DESCRIPTION
The Caddyfile in 'Front' uses blockchain.com while the current run Caddyfile.dev uses blockchain.info URLs.

Was getting a CSP error when setting up a new node, after updating manually the error went away.