### PR TITLE
Fix dev.env with correct guidance on Admin keys separated by spaces

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -40,18 +40,16 @@ ADD_IPS=
 # pre-configured seeds.
 ADD_SEEDS=
 
-# admin_public_keys is list of public keys delimited by commas or new-lines
+# admin_public_keys is list of public keys delimited by a space
 # which gives users access to the admin panel. If no keys are specified 
-# anyone can access the admin panel. You can add a space and a comment after 
-# every public key and leave a note about who the public key belongs to.
+# anyone can access the admin panel. 
 ADMIN_PUBLIC_KEYS=
 
-# super_admin_public_keys is a list of public keys delimited by commas or new-lines
+# super_admin_public_keys is a list of public keys delimited by a space
 # which gives users access to the super tab of the admin panel and select endpoints
 # for these privileged users.  At this time, super admins can adjust the reserve price
 # at which this node will sell $Clout, set the slippage fee applied to $CLOUT buys,
-# and manage verification of users on this node. You can add a space and a comment
-# after every public key and leave a note about who the public key belongs to.
+# and manage verification of users on this node. 
 SUPER_ADMIN_PUBLIC_KEYS=
 
 # When set, determines the port on which this node will listen for protocol-related
@@ -145,7 +143,7 @@ GLOBAL_STATE_REMOTE_NODE=
 # is also required to restrict access.
 GLOBAL_STATE_REMOTE_SECRET=
 
-# Accepts a comma-separated lists of origin domains that will be allowed as the
+# Accepts a space-separated lists of origin domains that will be allowed as the
 # Access-Control-Allow-Origin HTTP header. Defaults to * if not set.
 #
 # TODO: We should show some kind of warning or something if this option is set to *
@@ -159,8 +157,9 @@ ACCESS_CONTROL_ALLOW_ORIGINS=*
 # is the default right now.
 SECURE_HEADER_DEVELOPMENT=true
 
-# This is the domain that our secure middleware will accept requests from. We
-# also set the HTTP Access-Control-Allow-Origin
+# These are the domains that our secure middleware will accept requests from. 
+# Accepts a space-separated lists of origin domains.
+# We also set the HTTP Access-Control-Allow-Origin
 SECURE_HEADER_ALLOW_HOSTS=
 
 # Optional. Client-side amplitude key for instrumenting user behavior.


### PR DESCRIPTION
[backend uses Vipers 'GetStringSlice'](https://github.com/bitclout/backend/blob/main/cmd/config.go#L93) for 4 of the config options in dev.env. This means items within these options can only be separated by spaces.

Also removed the comment about using "space + comment" for each admin key - as this does not work.